### PR TITLE
Accommodate default JSON.NET date parsing

### DIFF
--- a/test/Serilog.Formatting.Compact.Reader.Tests/LogEventReaderTests.cs
+++ b/test/Serilog.Formatting.Compact.Reader.Tests/LogEventReaderTests.cs
@@ -1,4 +1,6 @@
-﻿using Serilog.Events;
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Serilog.Events;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -48,6 +50,16 @@ namespace Serilog.Formatting.Compact.Reader.Tests
             var evt = LogEventReader.ReadFromString(document);
 
             Assert.Equal("Hello, {{text}}", evt.MessageTemplate.Text);
+        }
+
+        [Fact]
+        public void HandlesDefaultJsonNetSerialization()
+        {
+            const string document = "{\"@t\":\"2016-10-12T04:20:58.0554314Z\",\"@m\":\"Hello\"}";
+            var jObject = JsonConvert.DeserializeObject<JObject>(document);
+            var evt = LogEventReader.ReadFromJObject(jObject);
+
+            Assert.Equal(DateTimeOffset.Parse("2016-10-12T04:20:58.0554314Z"), evt.Timestamp);
         }
     }
 }

--- a/test/Serilog.Formatting.Compact.Reader.Tests/project.json
+++ b/test/Serilog.Formatting.Compact.Reader.Tests/project.json
@@ -3,7 +3,8 @@
   "dependencies": {
     "Serilog.Formatting.Compact.Reader": { "target": "project" },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-rc2-build10025"
+    "dotnet-test-xunit": "1.0.0-rc2-build10025",
+    "Newtonsoft.Json": "9.0.1"
   },
   "buildOptions": {
     "keyFile": "../../asset/Serilog.snk",


### PR DESCRIPTION
When a custom serializer is used, timestamps will often be parsed by JSON.NET.