### PR TITLE
Remove NETStandard.Library dependency from .NET 4.5 target

### DIFF
--- a/src/Serilog.Formatting.Compact.Reader/project.json
+++ b/src/Serilog.Formatting.Compact.Reader/project.json
@@ -9,13 +9,16 @@
   },
 
   "dependencies": {
-    "NETStandard.Library": "1.6.0",
     "Newtonsoft.Json": "9.0.1",
     "Serilog": "2.3.0"
   },
 
   "frameworks": {
-    "netstandard1.0": {},
+    "netstandard1.0": {
+      "dependencies": {
+        "NETStandard.Library": "1.6.0"
+      }
+    },
     "net4.5": {}
   },
 


### PR DESCRIPTION
Fixes #7