### PR TITLE
Only use the special RenderableScalarValue type when required

### DIFF
--- a/example/RoundTrip/Program.cs
+++ b/example/RoundTrip/Program.cs
@@ -5,7 +5,7 @@ using System;
 using System.IO;
 using Serilog.Formatting.Compact;
 
-namespace Example
+namespace RoundTrip
 {
     public class Program
     {
@@ -17,6 +17,7 @@ namespace Example
             {
                 fileLog.Information("Hello, {@User}", new { Name = "nblumhardt", Id = 101 });
                 fileLog.Information("Number {N:x8}", 42);
+                fileLog.Information("String {S}", "Yes");
                 fileLog.Warning("Tags are {Tags}", new[] { "test", "orange" });
 
                 try
@@ -30,14 +31,13 @@ namespace Example
             }
 
             using (var console = new LoggerConfiguration()
-                .WriteTo.LiterateConsole()
+                .WriteTo.Console()
                 .CreateLogger())
             {
                 using (var clef = File.OpenText("log.clef"))
                 {
                     var reader = new LogEventReader(clef);
-                    LogEvent evt;
-                    while (reader.TryRead(out evt))
+                    while (reader.TryRead(out var evt))
                         console.Write(evt);
                 }
             }

--- a/example/RoundTrip/RoundTrip.csproj
+++ b/example/RoundTrip/RoundTrip.csproj
@@ -17,8 +17,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Serilog" Version="2.5.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="3.1.0" />
-    <PackageReference Include="Serilog.Sinks.Literate" Version="2.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.0.1" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.0.0" />
   </ItemGroup>
 

--- a/src/Serilog.Formatting.Compact.Reader/PropertyFactory.cs
+++ b/src/Serilog.Formatting.Compact.Reader/PropertyFactory.cs
@@ -49,7 +49,9 @@ namespace Serilog.Formatting.Compact.Reader
 
             var raw = value.Value<JValue>().Value;
 
-            return renderings != null ? new RenderableScalarValue(raw, renderings) : new ScalarValue(raw);
+            return renderings != null && renderings.Any() ? 
+                new RenderableScalarValue(raw, renderings) :
+                new ScalarValue(raw);
         }
     }
 }


### PR DESCRIPTION
Small thing - this lib uses a subclass of `ScalarValue` to preserve original rendering info. We only need to use this when there are actual renderings specified (the original check is broken).