### PR TITLE
Add .NET Standard 2.0 & 2.1, update sample to target .NET 3.1, add .NET 3.1 target to tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: '{build}'
 skip_tags: true
-image: Visual Studio 2017
+image: Visual Studio 2019
 configuration: Release
 install:
   - ps: mkdir -Force ".\build\" | Out-Null

--- a/example/RoundTrip/RoundTrip.csproj
+++ b/example/RoundTrip/RoundTrip.csproj
@@ -1,12 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>RoundTrip</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>RoundTrip</PackageId>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/serilog-formatting-compact-reader.sln
+++ b/serilog-formatting-compact-reader.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26430.6
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30523.141
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E673DF37-5F53-48F6-9991-D762B8E35548}"
 EndProject
@@ -54,5 +54,8 @@ Global
 		{D6A02FA9-860A-48AC-8288-8CEBC962D4DE} = {E673DF37-5F53-48F6-9991-D762B8E35548}
 		{961D5124-BBB2-4022-945E-1190BF6BE0C9} = {C3520C42-AC85-401C-B496-F51C816B784F}
 		{3C2D8E01-5580-426A-BDD9-EC59CD98E618} = {C76B8054-0892-42DA-83D5-88D731782FE8}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C0F6B3C6-5950-483C-8391-A2BFAD958790}
 	EndGlobalSection
 EndGlobal

--- a/src/Serilog.Formatting.Compact.Reader/Serilog.Formatting.Compact.Reader.csproj
+++ b/src/Serilog.Formatting.Compact.Reader/Serilog.Formatting.Compact.Reader.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>1.0.4</VersionPrefix>
-    <TargetFrameworks>netstandard1.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;netstandard1.0;net45</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Serilog.Formatting.Compact.Reader</AssemblyName>

--- a/test/Serilog.Formatting.Compact.Reader.Tests/Serilog.Formatting.Compact.Reader.Tests.csproj
+++ b/test/Serilog.Formatting.Compact.Reader.Tests/Serilog.Formatting.Compact.Reader.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>Serilog.Formatting.Compact.Reader.Tests</AssemblyName>
     <AssemblyOriginatorKeyFile>../../asset/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
- [x] `Serilog.Formatting.Compact.Reader` now also targets `netstandard2.0` and `netstandard2.1`
- [x] `Serilog.Formatting.Compact.Reader.Tests` now also tests on `netcoreapp3.1`
- [x] Roundtrip example project now targets `netcoreapp3.1`
- [x] Update solution file to VS2019
- [x] Update AppVeyor image to VS2019

![image](https://user-images.githubusercontent.com/177608/95661433-c7d06f00-0b05-11eb-9fab-6c5b4de5ca5d.png)

---

Closes #25
