### PR TITLE
Bugfix: Parse loglevel enum as case insensitive

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.202"
+    "version": "5.0.202",
+    "rollForward": "latestMajor"
   }
 }

--- a/src/Serilog.Formatting.Compact.Reader/LogEventReader.cs
+++ b/src/Serilog.Formatting.Compact.Reader/LogEventReader.cs
@@ -124,7 +124,7 @@ namespace Serilog.Formatting.Compact.Reader
 
             var level = LogEventLevel.Information;
             if (TryGetOptionalField(lineNumber, jObject, ClefFields.Level, out string l))
-                level = (LogEventLevel)Enum.Parse(typeof(LogEventLevel), l);
+                level = (LogEventLevel)Enum.Parse(typeof(LogEventLevel), l, true);
             Exception exception = null;
             if (TryGetOptionalField(lineNumber, jObject, ClefFields.Exception, out string ex))
                 exception = new TextException(ex);

--- a/test/Serilog.Formatting.Compact.Reader.Tests/LogEventReaderTests.clef
+++ b/test/Serilog.Formatting.Compact.Reader.Tests/LogEventReaderTests.clef
@@ -1,6 +1,6 @@
 ﻿{"@t":"2016-10-12T04:20:58.0554314Z","@mt":"Hello, {@User}","User":{"Name":"nblumhardt","Id":101}}
 {"@t":"2016-10-12T04:20:58.0684369Z","@mt":"Number {N:x8}","@r":["0000002a"],"N":42}
-{"@t":"2016-10-12T04:20:58.0724384Z","@mt":"Tags are {Tags}","@l":"Warning","Tags":["test","orange"]}
-{"@t":"2016-10-12T04:20:58.0904378Z","@mt":"Something failed","@l":"Error","@x":"System.DivideByZeroException: Attempted to divide by zero.\r\n   at Example.Program.Main(String[] args) in C:\\Development\\nblumhardt\\serilog-formatting-compact-reader\\example\\RoundTrip\\Program.cs:line 24"}
+{"@t":"2016-10-12T04:20:58.0724384Z","@mt":"Tags are {Tags}","@l":"WaRNiNg","Tags":["test","orange"]}
+{"@t":"2016-10-12T04:20:58.0904378Z","@mt":"Something failed","@l":"ERROR","@x":"System.DivideByZeroException: Attempted to divide by zero.\r\n   at Example.Program.Main(String[] args) in C:\\Development\\nblumhardt\\serilog-formatting-compact-reader\\example\\RoundTrip\\Program.cs:line 24"}
 {"@t":"2016-10-12T04:20:59.0554314Z","@m":"Hello, nblumhardt","@i":"123abc00","N":42}
 {"@t":"2019-09-10T04:56:50.608125300+00:00","@l":null,"Method":"POST","@mt":"HTTP {Method} {RequestPath} responded {StatusCode} in {Elapsed:0.000} ms","RequestPath":"/api/customers","SourceContext":"DemoMiddleware","@r":["799.724"],"Elapsed":799.72430000000008,"@i":2568106828,"@m":"HTTP POST /api/customers responded 400 in 799.724 ms","RequestId":"8786927172fc4abe","StatusCode":400}


### PR DESCRIPTION
This is to help fix a bug from a user using the Desktop/Electron app I created for reading Compact Logs, where a user has the LogLevel in uppercase.
https://github.com/warrenbuckley/Compact-Log-Format-Viewer/issues/658

This is a simple fix where it passes a bool to Enum.Parse to allow it to be case insensitive.

Hoping I can get this PR marked as `hacktoberfest-accepted` to count to my contribution for this years Hacktobefest please @nblumhardt 