### PR TITLE
Added more format checks to unify thrown Exceptions

### DIFF
--- a/src/Serilog.Formatting.Compact.Reader/LogEventReader.cs
+++ b/src/Serilog.Formatting.Compact.Reader/LogEventReader.cs
@@ -84,11 +84,11 @@ public class LogEventReader : IDisposable
         }
         catch (Exception ex)
         {
-            throw new InvalidDataException($"The data on line {_lineNumber} is not a complete JSON object.", ex);
+            throw new InvalidDataException($"The data on line {_lineNumber} could not be deserialized.", ex);
         }
 
         if (data is not JObject fields)
-            throw new InvalidDataException($"The data on line {_lineNumber} could not be deserialized.");
+            throw new InvalidDataException($"The data on line {_lineNumber} is not a complete JSON object.");
 
         evt = ReadFromJObject(_lineNumber, fields);
         return true;

--- a/src/Serilog.Formatting.Compact.Reader/LogEventReader.cs
+++ b/src/Serilog.Formatting.Compact.Reader/LogEventReader.cs
@@ -88,7 +88,7 @@ public class LogEventReader : IDisposable
         }
 
         if (data is not JObject fields)
-            throw new InvalidDataException($"The data on line {_lineNumber} is not a complete JSON object.");
+            throw new InvalidDataException($"The data on line {_lineNumber} could not be deserialized.");
 
         evt = ReadFromJObject(_lineNumber, fields);
         return true;
@@ -114,7 +114,7 @@ public class LogEventReader : IDisposable
         }
         catch (Exception ex)
         {
-            throw new InvalidDataException($"The document is not a complete JSON object.", ex);
+            throw new InvalidDataException($"The document could not be deserialized.", ex);
         }
 
         if (result is not JObject jObject)
@@ -149,7 +149,7 @@ public class LogEventReader : IDisposable
 
         var level = LogEventLevel.Information;
         if (TryGetOptionalField(lineNumber, jObject, ClefFields.Level, out var l) && !Enum.TryParse(l, true, out level))
-            throw new InvalidDataException($"The `{ClefFields.Level}` value on line {lineNumber} is not a valid {nameof(LogEventLevel)}.");
+            throw new InvalidDataException($"The `{ClefFields.Level}` value on line {lineNumber} is not a valid `{nameof(LogEventLevel)}`.");
 
         Exception? exception = null;
         if (TryGetOptionalField(lineNumber, jObject, ClefFields.Exception, out var ex))
@@ -247,8 +247,8 @@ public class LogEventReader : IDisposable
             var dt = token.Value<JValue>()!.Value;
             if (dt is DateTimeOffset offset)
                 return offset;
-            else
-                return (DateTime)dt!;
+
+            return (DateTime)dt!;
         }
         else
         {
@@ -257,7 +257,7 @@ public class LogEventReader : IDisposable
 
             var text = token.Value<string>()!;
             if (!DateTimeOffset.TryParse(text, out var offset))
-                throw new InvalidDataException($"The value of `{field}` on line {lineNumber} is not in a supported format.");
+                throw new InvalidDataException($"The value of `{field}` on line {lineNumber} is not in a supported timestamp format.");
 
             return offset;
         }

--- a/src/Serilog.Formatting.Compact.Reader/LogEventReader.cs
+++ b/src/Serilog.Formatting.Compact.Reader/LogEventReader.cs
@@ -114,11 +114,11 @@ public class LogEventReader : IDisposable
         }
         catch (Exception ex)
         {
-            throw new InvalidDataException($"The document could not be deserialized.", ex);
+            throw new InvalidDataException("The document could not be deserialized.", ex);
         }
 
         if (result is not JObject jObject)
-            throw new InvalidDataException($"The document is not a complete JSON object.");
+            throw new InvalidDataException("The document is not a complete JSON object.");
 
         return ReadFromJObject(jObject);
     }

--- a/src/Serilog.Formatting.Compact.Reader/MessageTemplateSyntax.cs
+++ b/src/Serilog.Formatting.Compact.Reader/MessageTemplateSyntax.cs
@@ -4,8 +4,6 @@ static class MessageTemplateSyntax
 {
     public static string Escape(string text)
     {
-            if (text == null) throw new ArgumentNullException(nameof(text));
-
-            return text.Replace("{", "{{").Replace("}", "}}");
-        }
+        return text.Replace("{", "{{").Replace("}", "}}");
+    }
 }

--- a/test/Serilog.Formatting.Compact.Reader.Tests/LogEventReaderTests.cs
+++ b/test/Serilog.Formatting.Compact.Reader.Tests/LogEventReaderTests.cs
@@ -111,4 +111,33 @@ public class LogEventReaderTests
         Assert.Equal("1befc31e94b01d1a473f63a7905f6c9b", evt.TraceId.ToString());
         Assert.Equal("bb1111820570b80e", evt.SpanId.ToString());
     }
+
+  [Fact]
+  public void EmptyDocumentThrowsInvalidDataException()
+  {
+    Assert.Throws<InvalidDataException>(() => LogEventReader.ReadFromString(string.Empty));
+  }
+
+  [Theory]
+  [InlineData("[]")]
+  [InlineData("{}")]
+  [InlineData("#$%")]
+  [InlineData("{\"@t\":0}")]
+  [InlineData("{\"@t\":\"2016-02-30\"}")]
+  [InlineData("{\"@t\":\"2016-02-12\"")]
+  [InlineData("{\"@t\":\"2016-02-12\",\"@l\":\"Trace\"}")]
+  [InlineData("{\"@t\":\"2016-02-12\",\"@r\":\"[]\"}")]
+  [InlineData("{\"@t\":\"2016-02-12\",\"@m\":0}")]
+  [InlineData("{\"@t\":\"2016-02-12\",\"@mt\":[]}")]
+  [InlineData("{\"@t\":\"2016-02-12\",\"@x\":[\"\"]}")]
+  [InlineData("{\"@t\":\"2016-02-12\",\"@tr\":{}}")]
+  [InlineData("{\"@t\":\"2016-02-12\",\"@sp\":true}")]
+  [InlineData("{\"@t\":\"2016-02-12\",\"@i\":true}")]
+  public void InvalidDataThrowsInvalidDataException(string document)
+  {
+    using var reader = new LogEventReader(new StringReader(document));
+
+    Assert.Throws<InvalidDataException>(() => reader.TryRead(out _));
+    Assert.Throws<InvalidDataException>(() => LogEventReader.ReadFromString(document));
+  }
 }

--- a/test/Serilog.Formatting.Compact.Reader.Tests/LogEventReaderTests.cs
+++ b/test/Serilog.Formatting.Compact.Reader.Tests/LogEventReaderTests.cs
@@ -98,10 +98,10 @@ public class LogEventReaderTests
     {
         const string document = "{\"@t\":\"2016-10-12T04:20:58.0554314Z\",\"@i\":42,\"@m\":\"Hello\"}";
         var evt = LogEventReader.ReadFromString(document);
-            
+
         Assert.Equal((uint)42, ((ScalarValue)evt.Properties["@i"]).Value);
     }
-        
+
     [Fact]
     public void ReadsTraceAndSpanIds()
     {
@@ -112,32 +112,32 @@ public class LogEventReaderTests
         Assert.Equal("bb1111820570b80e", evt.SpanId.ToString());
     }
 
-  [Fact]
-  public void EmptyDocumentThrowsInvalidDataException()
-  {
-    Assert.Throws<InvalidDataException>(() => LogEventReader.ReadFromString(string.Empty));
-  }
+    [Fact]
+    public void EmptyDocumentThrowsInvalidDataException()
+    {
+        Assert.Throws<InvalidDataException>(() => LogEventReader.ReadFromString(string.Empty));
+    }
 
-  [Theory]
-  [InlineData("[]")]
-  [InlineData("{}")]
-  [InlineData("#$%")]
-  [InlineData("{\"@t\":0}")]
-  [InlineData("{\"@t\":\"2016-02-30\"}")]
-  [InlineData("{\"@t\":\"2016-02-12\"")]
-  [InlineData("{\"@t\":\"2016-02-12\",\"@l\":\"Trace\"}")]
-  [InlineData("{\"@t\":\"2016-02-12\",\"@r\":\"[]\"}")]
-  [InlineData("{\"@t\":\"2016-02-12\",\"@m\":0}")]
-  [InlineData("{\"@t\":\"2016-02-12\",\"@mt\":[]}")]
-  [InlineData("{\"@t\":\"2016-02-12\",\"@x\":[\"\"]}")]
-  [InlineData("{\"@t\":\"2016-02-12\",\"@tr\":{}}")]
-  [InlineData("{\"@t\":\"2016-02-12\",\"@sp\":true}")]
-  [InlineData("{\"@t\":\"2016-02-12\",\"@i\":true}")]
-  public void InvalidDataThrowsInvalidDataException(string document)
-  {
-    using var reader = new LogEventReader(new StringReader(document));
+    [Theory]
+    [InlineData("[]")]
+    [InlineData("{}")]
+    [InlineData("#$%")]
+    [InlineData("{\"@t\":0}")]
+    [InlineData("{\"@t\":\"2016-02-30\"}")]
+    [InlineData("{\"@t\":\"2016-02-12\"")]
+    [InlineData("{\"@t\":\"2016-02-12\",\"@l\":\"Trace\"}")]
+    [InlineData("{\"@t\":\"2016-02-12\",\"@r\":\"[]\"}")]
+    [InlineData("{\"@t\":\"2016-02-12\",\"@m\":0}")]
+    [InlineData("{\"@t\":\"2016-02-12\",\"@mt\":[]}")]
+    [InlineData("{\"@t\":\"2016-02-12\",\"@x\":[\"\"]}")]
+    [InlineData("{\"@t\":\"2016-02-12\",\"@tr\":{}}")]
+    [InlineData("{\"@t\":\"2016-02-12\",\"@sp\":true}")]
+    [InlineData("{\"@t\":\"2016-02-12\",\"@i\":true}")]
+    public void InvalidDataThrowsInvalidDataException(string document)
+    {
+        using var reader = new LogEventReader(new StringReader(document));
 
-    Assert.Throws<InvalidDataException>(() => reader.TryRead(out _));
-    Assert.Throws<InvalidDataException>(() => LogEventReader.ReadFromString(document));
-  }
+        Assert.Throws<InvalidDataException>(() => reader.TryRead(out _));
+        Assert.Throws<InvalidDataException>(() => LogEventReader.ReadFromString(document));
+    }
 }


### PR DESCRIPTION
This PR tries to solve an issue that `TryRead` can throw Exceptions apart from `InvalidDataException` in some edge cases.