### PR TITLE
Added support for TryReadAsync() with CancellationToken

### DIFF
--- a/src/Serilog.Formatting.Compact.Reader/LogEventReader.cs
+++ b/src/Serilog.Formatting.Compact.Reader/LogEventReader.cs
@@ -102,6 +102,27 @@ public class LogEventReader : IDisposable
         return ParseLine(line);
     }
 
+#if NET7_0_OR_GREATER
+    /// <inheritdoc cref="TryReadAsync()" />
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    public async Task<LogEvent?> TryReadAsync(CancellationToken cancellationToken)
+    {
+        var line = await _text.ReadLineAsync(cancellationToken).ConfigureAwait(false);
+        _lineNumber++;
+        while (string.IsNullOrWhiteSpace(line))
+        {
+            if (line == null)
+            {
+                return null;
+            }
+            line = await _text.ReadLineAsync(cancellationToken).ConfigureAwait(false);
+            _lineNumber++;
+        }
+
+        return ParseLine(line);
+    }
+#endif
+
     /// <summary>
     /// Read a single log event from a JSON-encoded document.
     /// </summary>

--- a/src/Serilog.Formatting.Compact.Reader/LogEventReader.cs
+++ b/src/Serilog.Formatting.Compact.Reader/LogEventReader.cs
@@ -102,7 +102,7 @@ public class LogEventReader : IDisposable
         return ParseLine(line);
     }
 
-#if NET7_0_OR_GREATER
+#if FEATURE_READ_LINE_ASYNC_CANCELLATION
     /// <inheritdoc cref="TryReadAsync()" />
     /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
     public async Task<LogEvent?> TryReadAsync(CancellationToken cancellationToken)

--- a/src/Serilog.Formatting.Compact.Reader/Serilog.Formatting.Compact.Reader.csproj
+++ b/src/Serilog.Formatting.Compact.Reader/Serilog.Formatting.Compact.Reader.csproj
@@ -28,6 +28,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+    <DefineConstants>$(DefineConstants);FEATURE_READ_LINE_ASYNC_CANCELLATION</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Serilog" Version="4.0.0" />

--- a/test/Serilog.Formatting.Compact.Reader.Tests/LogEventReaderTests.cs
+++ b/test/Serilog.Formatting.Compact.Reader.Tests/LogEventReaderTests.cs
@@ -4,6 +4,7 @@ using Serilog.Events;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -156,6 +157,11 @@ public class LogEventReaderTests
 
         using var asyncReader = new LogEventReader(new StringReader(document));
         await Assert.ThrowsAsync<InvalidDataException>(asyncReader.TryReadAsync);
+
+#if NET7_0_OR_GREATER
+        using var asyncReader2 = new LogEventReader(new StringReader(document));
+        await Assert.ThrowsAsync<InvalidDataException>(async () => await asyncReader2.TryReadAsync(CancellationToken.None));
+#endif
 
         Assert.Throws<InvalidDataException>(() => LogEventReader.ReadFromString(document));
     }


### PR DESCRIPTION
From .NET 7, a new [`ReadLineAsync`](https://learn.microsoft.com/en-us/dotnet/api/system.io.streamreader.readlineasync?view=net-7.0#system-io-streamreader-readlineasync(system-threading-cancellationtoken)) method has been available, which has a `CancellationToken` as a parameter. This PR was created to support this newer overload.